### PR TITLE
feat: allow passing headers as an input

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Works in tandem with:
 | federated   | false   | no                     |
 | subgraph    |         | no, if federated false |
 | server      |         | apollo server url      |
+| headers     |         | no, JSON if provided   |
 
 ## outputs
 | name   | description                |
@@ -34,6 +35,7 @@ jobs:
         federated: true
         subgraph: products
         server: http://apollo:3000/
+        headers: {"token": "s3cr3t"}
       env:
         APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
 ```

--- a/index.js
+++ b/index.js
@@ -34,10 +34,15 @@ const setOutput = (schema) => {
 const parseHeaders = (rawHeaders) => {
   if (rawHeaders === '') return []
 
-  const headers = JSON.parse(rawHeaders)
-  return Object.entries(headers).reduce((acc, header) => {
-    return acc.concat(['--header', header.join(':')])
-  }, [])
+  try {
+    const headers = JSON.parse(rawHeaders)
+    return Object.entries(headers).reduce((acc, header) => {
+      return acc.concat(['--header', header.join(':')])
+    }, [])
+  } catch(error) {
+    core.error('Failed to parse headers input, is it valid JSON?')
+    throw error
+  }
 }
 
 const getInput = () => {


### PR DESCRIPTION
Sometimes when making a request to a GraphQL endpoint, you need to pass headers for the request to be successful. A common example is token headers used for authorization.

This PR adds a new input, `headers`, which accepts a JSON string to represent any headers that should be included in the introspection request.

Example job config:
```yml
- uses: w33ble/rover-introspect
      with:
        federated: true
        subgraph: products
        server: http://apollo:3000/
        headers: {"token": "s3cr3t", "machine_name": "localhost" }
      env:
        APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
```

Resulting rover request:
```sh
rover subgraph introspect http://apollo:3000/ --header token:s3cr3t --header machine_name:localhost
```